### PR TITLE
Fix inconsistent interview page links

### DIFF
--- a/cleanup-plan.md
+++ b/cleanup-plan.md
@@ -1,0 +1,42 @@
+# Interview Page Cleanup Plan
+
+## Current Issues Identified
+
+1. **Duplicate Interview Pages**:
+   - `interview.html` (older version)
+   - `interview-new.html` (current version)
+
+2. **Duplicate JavaScript Files**:
+   - `js/interview.js` (older version)
+   - `js/interview-new.js` (current version)
+
+3. **Inconsistent Navigation**:
+   - Main navigation and link in hero section should consistently point to the same interview page
+   - Fixed: Hero section "Find Lifeline Plans" button now points to `interview-new.html`
+
+## Recommended Actions
+
+### Immediate Actions (Completed)
+- ✅ Update hero section link on homepage to point to `interview-new.html`
+
+### Short-term Actions (Next Sprint)
+1. Remove unused `interview.html` file
+2. Remove unused `js/interview.js` file
+3. Update architecture documentation to reflect current state
+
+### Long-term Actions (Future Consideration)
+1. Rename `interview-new.html` to `interview.html` for cleaner URLs
+2. Rename `js/interview-new.js` to `js/interview.js` for consistency
+3. Update all references accordingly
+
+## Benefits of Cleanup
+- Reduced maintenance burden
+- Elimination of confusion when making changes
+- More consistent user experience
+- Cleaner codebase
+- Better documentation
+
+## Implementation Timeline
+- **Phase 1**: Fix immediate navigation inconsistency (current PR)
+- **Phase 2**: Remove unused files (next sprint)
+- **Phase 3**: Consider file renaming for cleaner structure (future roadmap item) 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
             <div class="container">
                 <h1>Affordable Connectivity for All</h1>
                 <p>Helping eligible households access affordable internet and phone services through the Lifeline program.</p>
-                <a href="interview.html" class="btn btn--secondary">Find Lifeline Plans</a>
+                <a href="interview-new.html" class="btn btn--secondary">Find Lifeline Plans</a>
             </div>
         </section>
 

--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,16 @@
+# Fix inconsistent interview page links
+
+## Changes Made
+
+- Fixed inconsistent links between homepage hero button and navigation menu
+- Both now point to interview-new.html for a consistent user experience
+- Added cleanup plan document outlining future steps to reduce code duplication
+
+## Issue Fixed
+
+This PR addresses the issue where changes to the site sometimes reverted to an outdated version of the home page with 'Learn More' button instead of 'Find Lifeline Plans'.
+
+## Testing
+
+- Verified all navigation links point to interview-new.html
+- Added documentation for future cleanup steps 


### PR DESCRIPTION
## Changes Made\n\n- Fixed inconsistent links between homepage hero button and navigation menu\n- Both now point to interview-new.html for a consistent user experience\n- Added cleanup plan document outlining future steps to reduce code duplication\n\n## Issue Fixed\n\nThis PR addresses the issue where changes to the site sometimes reverted to an outdated version of the home page with 'Learn More' button instead of 'Find Lifeline Plans'.\n\n## Testing\n\n- Verified all navigation links point to interview-new.html\n- Added documentation for future cleanup steps