### PR TITLE
Update interview page text to reference Lifeline plans

### DIFF
--- a/interview.html
+++ b/interview.html
@@ -294,7 +294,7 @@
     <main>
         <div class="mobile-plan-finder">
             <h1 class="finder-title">Mobile Plan Finder</h1>
-            <p class="finder-subtitle">Get personalized mobile plan recommendations powered by AI</p>
+            <p class="finder-subtitle">Get personalized Lifeline plan recommendations</p>
 
             <form id="planForm" class="question-section">
                 <label for="requirements" class="question-label">What are you looking for in a Lifeline plan?</label>

--- a/interview.html
+++ b/interview.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mobile Plan Finder - Georgia Connects</title>
+    <title>Find the Lifeline Plan That Fits You - Georgia Connects</title>
     <meta name="description" content="Find the perfect mobile plan for your needs with AI-powered recommendations.">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/variables.css">
@@ -293,7 +293,7 @@
 
     <main>
         <div class="mobile-plan-finder">
-            <h1 class="finder-title">Mobile Plan Finder</h1>
+            <h1 class="finder-title">Find the Lifeline Plan That Fits You</h1>
             <p class="finder-subtitle">Get personalized Lifeline plan recommendations</p>
 
             <form id="planForm" class="question-section">

--- a/interview.html
+++ b/interview.html
@@ -297,7 +297,7 @@
             <p class="finder-subtitle">Get personalized mobile plan recommendations powered by AI</p>
 
             <form id="planForm" class="question-section">
-                <label for="requirements" class="question-label">What are you looking for in a mobile plan?</label>
+                <label for="requirements" class="question-label">What are you looking for in a Lifeline plan?</label>
                 <textarea 
                     id="requirements" 
                     class="user-input" 


### PR DESCRIPTION
This PR updates the interview page text to reference Lifeline plans instead of mobile plans. Changes made: - Updated prompt from 'What are you looking for in a mobile plan?' to 'What are you looking for in a Lifeline plan?' - Changed subtitle from 'Get personalized mobile plan recommendations powered by AI' to 'Get personalized Lifeline plan recommendations' - Updated header from 'Mobile Plan Finder' to 'Find the Lifeline Plan That Fits You' - Updated page title to match new header. These changes help maintain consistency in messaging around Lifeline plans throughout the application.